### PR TITLE
Ajout du GET pour récupération cookie GTK

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Ici se trouve toute la documentation, assurez-vous d'avoir lu la référence ava
 ## Login
 
 Depuis le 24/03/2025, il est nécessaire, avant le login, de récupérer un cookies "GTK" en appelant (sinon l'API vous annonce un login/mot de passe incorrect - il n'y a pas ce mecanisme sur l'admin)
+
 __GET__ `/v3/login.awp?gtk=1&v=4.75.0`
 
 Récupérer la valeur de ce cookies et le passer dans le post de login en header "X-Gtk".

--- a/README.md
+++ b/README.md
@@ -208,9 +208,10 @@ Ici se trouve toute la documentation, assurez-vous d'avoir lu la référence ava
 
 ## Login
 
-Depuis le 24/03/2025, il est nécessaire, avant le login, de récupérer un cookies "GTK" en appelant (sinon l'API vous annonce un login/mot de passe incorrect - il n'y a pas ce mecanisme sur l'admin)
+Depuis le 24/03/2025, il est nécessaire, avant le login, de récupérer un cookies "GTK" en appelant : 
 
 __GET__ `/v3/login.awp?gtk=1&v=4.75.0`
+(sinon l'API vous annonce un login/mot de passe incorrect - il n'y a pas ce mecanisme sur l'admin)
 
 Récupérer la valeur de ce cookies et le passer dans le post de login en header "X-Gtk".
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,12 @@ Ici se trouve toute la documentation, assurez-vous d'avoir lu la référence ava
 
 ## Login
 
-__POST__ `/v3/login.awp`
+Depuis le 24/03/2025, il est nécessaire, avant le login, de récupérer un cookies "GTK" en appelant (sinon l'API vous annonce un login/mot de passe incorrect - il n'y a pas ce mecanisme sur l'admin)
+__GET__ `/v3/login.awp?gtk=1&v=4.75.0`
+
+Récupérer la valeur de ce cookies et le passer dans le post de login en header "X-Gtk".
+
+__POST__ `/v3/login.awp?v=4.75.0`
 
 Data en body :
 ```json


### PR DESCRIPTION
Depuis le début de semaine, je ne peux plus me connecter.
Ils ont ajouté une étape supplémentaire : GET sur login.awp : on récupère le cookie et il faut passer sa valeur dans le POST du login en header